### PR TITLE
Updated README for new grunt.file.read convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ The password to authenticate on remote system.
 
 ###### privateKey ```string```
 
-A string containing the contents of the private key to use to authenticate with the remote system, you can load this from a file using ```grunt.file.load```. Be careful you don't put this into source control unless you mean it!
+A string containing the contents of the private key to use to authenticate with the remote system, you can load this from a file using ```grunt.file.read```. Be careful you don't put this into source control unless you mean it!
 
 ```js
 options: {
-  privateKey: grunt.file.load("id_rsa"),
+  privateKey: grunt.file.read("id_rsa"),
   passphrase: <%= secret.passphrase %>
 }
 ```


### PR DESCRIPTION
I was trying to get private key auth going and found that grunt no longer supports grunt.file.load--it seems to have been removed in favor of grunt.file.read.
