### PR TITLE
Encoding Issues

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -117,16 +117,14 @@ module.exports = function (grunt) {
             }
 
             async.eachSeries(fileQueue, function (file, callback) {
-              var from = fs.createReadStream(file.src);
-              var to = sftp.createWriteStream(file.dest);
-
-              to.on('close', function () {
+              grunt.verbose.writeln('copying ' + file.src + ' to ' + file.dest);
+              sftp.fastPut(file.src, file.dest, function (err) {
+                if (err) {
+                  return callback(err);
+                }
                 grunt.verbose.writeln('copied ' + file.src + ' to ' + file.dest);
                 callback();
               });
-
-              grunt.verbose.writeln('copying ' + file.src + ' to ' + file.dest);
-              from.pipe(to);
             }, function (err) {
               sftp.end();
               callback(err);


### PR DESCRIPTION
Me again,

Since the last release, I have no idea why, but some of my uploads are experiencing the occasional bad character encoding... and it's literally a single character that balls's up. The one character will turn itself in to a 1000 or so characters that are unrecognised by the receiving server. I've been testing an ploughing away trying to figure out what the hell would cause such an oddity but have failed to figure out the exact problem.

However, if I switch the file upload method from stream piping to SSH2's  SFTP#fastPut method the problem no longer exists. I've had a look at the method and it does a lot of manual work with chunking buffers and it also takes the time of specifying the length of the stream. Somewhere deep within there is magic that fixes this problem.

I've tested the method with text and binary files and all seems ok.

Here's the change if you wish to use it.

Ta,
John
