### PR TITLE
support defining & referencing ssh configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ sshexec: {
 }
 ```
 
+Or, specifying SSH configuration at runtime as a command line option:
+
+```sh
+$ grunt sshexec:someTask --config myhost
+```
+
 ## Description
 
 ### sftp

--- a/tasks/sshexec.js
+++ b/tasks/sshexec.js
@@ -33,6 +33,11 @@ module.exports = function (grunt) {
 
     var rawOptions = this.options();
     grunt.verbose.writeflags(rawOptions, 'Raw Options');
+    
+    var config;
+    if ( (! options.config) && (config = grunt.option('config'))) {
+      options.config = config;
+    }
 
     if (options.config && grunt.util._(options.config).isString()) {
       this.requiresConfig(['sshconfig', options.config]);


### PR DESCRIPTION
Support defining & referencing ssh configurations under an "sshconfig" property.
This allows you to re-use them between different targets / commands.
Allows per-property overrides of all options at both task and target levels.
