### PR TITLE
Added privateKeyPath support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,20 @@ options: {
 }
 ```
 
+###### privateKeyPath ```string```
+
+A string containing path to a private key to use to authenticate with the remote system. Useful when same Gruntfile.js is used by multiple users with their own keys.
+
+```js
+options: {
+  privateKeyPath: <%= secret.keypath %>,
+  passphrase: <%= secret.passphrase %>
+}
+```
+
 ###### passphrase ```string```
 
-The passphrase to use with the ```privateKey```. As per the ```privateKey```, do not expose this in your Gruntfile or anywhere that'll end up public unless you mean it, load it from an external file.
+The passphrase to use with the ```privateKey``` or ```privateKeyPath```. As per the ```privateKey```, do not expose this in your Gruntfile or anywhere that'll end up public unless you mean it, load it from an external file.
 
 ###### host ```string```
 

--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -163,6 +163,10 @@ module.exports = function (grunt) {
       connectionOptions.privateKey = options.privateKey;
       connectionOptions.passphrase = options.passphrase;
     }
+    else if (options.privateKeyPath) {
+      connectionOptions.privateKey = fs.readFileSync(options.privateKeyPath);
+      connectionOptions.passphrase = options.passphrase;
+    }
     else {
       connectionOptions.password = options.password;
     }

--- a/tasks/sshexec.js
+++ b/tasks/sshexec.js
@@ -13,8 +13,9 @@ module.exports = function (grunt) {
 
   grunt.util = grunt.util || grunt.utils;
 
-  grunt.registerMultiTask('sshexec', 'Executes a shell command on a remote machine', function () {
+  grunt.registerMultiTask('sshexec', 'Executes a shell command on a remote machine', function () {    
     var utillib = require('./lib/util').init(grunt);
+    var fs = require('fs');
     var Connection = require('ssh2');
     var c = new Connection();
 
@@ -96,6 +97,10 @@ module.exports = function (grunt) {
 
     if (options.privateKey) {
       connectionOptions.privateKey = options.privateKey;
+      connectionOptions.passphrase = options.passphrase;
+    }
+    else if (options.privateKeyPath) {
+      connectionOptions.privateKey = fs.readFileSync(options.privateKeyPath);
       connectionOptions.passphrase = options.passphrase;
     }
     else {


### PR DESCRIPTION
It is my understanding that: 

``` js
privateKey: grunt.file.read('<%= config.passphrase %>'),
passphrase: '<%= config.passphrase %>'
```

is not possible (grunt doesn't understand template variable within it's functions). 

This is kind of needed when multiple users use the same Gruntfile.js. I decided to make a little patch which adds support to private key paths. I changed README.md to reflect this addition, but I did not modify neither Release History nor package.json

If you find this worthy addition please apply the patch and bump npm version. Thanks :)
