### PR TITLE
Add options to allow use of SSH agent for authentication in addition to

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -24,6 +24,7 @@ module.exports = function (grunt) {
       host: false,
       username: false,
       password: false,
+      agent: "",
       port: utillib.port,
       minimatch: {},
       srcBasePath: "",
@@ -163,8 +164,10 @@ module.exports = function (grunt) {
       connectionOptions.privateKey = options.privateKey;
       connectionOptions.passphrase = options.passphrase;
     }
-    else {
+    else if (options.password) {
       connectionOptions.password = options.password;
+    } else {
+      connectionOptions.agent = options.agent;
     }
 
     c.connect(connectionOptions);


### PR DESCRIPTION
password and public/private key.

Authentication via SSH agent is supported by the underlying ssh2 library
that grunt-sftp uses, and so passing those options to ssh2 via connect()
allows use of that mechanism.
