### PR TITLE
Add agent option to sshexec task

### DIFF
--- a/tasks/sshexec.js
+++ b/tasks/sshexec.js
@@ -27,6 +27,7 @@ module.exports = function (grunt) {
       host: false,
       username: false,
       password: false,
+      agent: "",
       port: utillib.port,
       ignoreErrors: false,
       minimatch: {}
@@ -114,8 +115,10 @@ module.exports = function (grunt) {
       connectionOptions.privateKey = options.privateKey;
       connectionOptions.passphrase = options.passphrase;
     }
-    else {
+    else if (options.password) {
       connectionOptions.password = options.password;
+    } else {
+      connectionOptions.agent = options.agent;
     }
 
     c.connect(connectionOptions);


### PR DESCRIPTION
Someone already added the same thing to sftp. I would also like to use this for the sshexec task. This simple edit works for me (and is identical to the one for sftp. I suppose both of the tasks could be refactored a bit to share the same options and connection code since they are so similar... But my nodefu is not that strong yet.
