### PR TITLE
Fix error when no passphrase is provided

### DIFF
--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -84,7 +84,10 @@ exports.init = function (grunt) {
 
     if (options.privateKey) {
       connectionOptions.privateKey = options.privateKey.trim();
-      connectionOptions.passphrase = options.passphrase.trim();
+      
+      if(options.passphrase) {
+        connectionOptions.passphrase = options.passphrase.trim();
+      }
     }
     else if (options.password) {
       connectionOptions.password = options.password;


### PR DESCRIPTION
The latest update throws the following error when you don't provide `options.passphrase`:

```
Warning: Cannot call method 'trim' of undefined Use --force to continue.
```
