### PR TITLE
allow sftp task to use the shared sshconfig

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -32,6 +32,19 @@ module.exports = function (grunt) {
       directoryPermissions: parseInt(755, 8)
     });
 
+    grunt.verbose.writeflags(options, 'Raw Options');
+
+    var config;
+    if ((!options.config) && (config = grunt.option('config'))) {
+      options.config = config;
+    }
+
+    if (options.config && grunt.util._(options.config).isString()) {
+      this.requiresConfig(['sshconfig', options.config]);
+      var configOptions = grunt.config.get(['sshconfig', options.config]);
+      options = grunt.util._.extend(options, configOptions);
+    }
+
     grunt.verbose.writeflags(options, 'Options');
 
     var files = this.files;

--- a/tasks/sshexec.js
+++ b/tasks/sshexec.js
@@ -33,8 +33,7 @@ module.exports = function (grunt) {
       minimatch: {}
     });
 
-    var rawOptions = this.options();
-    grunt.verbose.writeflags(rawOptions, 'Raw Options');
+    grunt.verbose.writeflags(options, 'Raw Options');
 
     var config;
     if ((!options.config) && (config = grunt.option('config'))) {
@@ -44,7 +43,7 @@ module.exports = function (grunt) {
     if (options.config && grunt.util._(options.config).isString()) {
       this.requiresConfig(['sshconfig', options.config]);
       var configOptions = grunt.config.get(['sshconfig', options.config]);
-      options = grunt.util._.extend(configOptions, rawOptions);
+      options = grunt.util._.extend(options, configOptions);
     }
 
     grunt.verbose.writeflags(options, 'Options');


### PR DESCRIPTION
two bits: 
- allow sftp task to use the shared sshconfig
- allow overriding sshconfig properties in the task config.

The second bit was necessary because the basic options for sshexec are different to sftp, so you need to merge the raw options with the sshconfig to get the correct output set for sftp.

i.e.

```
sshconfig: {
  myhost: {
    host: 'myhost',
    port: 22,
    ignoreErrors: false
  }
},
sftp: {
  copy: {
    files: {
        "./" : 'dist/*json'
    },
    options: {
        srcBasePath: 'dist/',
        createDirectories: true
  }
},
sshexec: {
  uptime: {
    command: 'uptime'
  }
  rm: {
    command: 'rm somefile.txt',
    options: {
        ignoreErrors: true
    }
}

```
