### PR TITLE
Use stat() instead of opendir() for checking existence of a dir in sftpHelpers

### DIFF
--- a/tasks/lib/sftpHelpers.js
+++ b/tasks/lib/sftpHelpers.js
@@ -16,7 +16,7 @@ exports.init = function (grunt) {
     var ptr = 0;
 
     var mkdir = function (path, callback) {
-      c.opendir(currentPath, function (error, handle) {
+      c.stat(currentPath, function (error, stat) {
         if (error) {
           grunt.verbose.writeln("Creating " + currentPath);
           c.mkdir(currentPath, attributes, function (error) {

--- a/test/sftpHelpers_test.js
+++ b/test/sftpHelpers_test.js
@@ -29,6 +29,7 @@ module.exports = {
     'use strict';
     conn = {
       opendir: function () {},
+      stat: function () {},
       mkdir: function () {}
     };
 
@@ -37,10 +38,10 @@ module.exports = {
   },
   "existing directories": function (test) {
     'use strict';
-    mock.expects("opendir").withArgs("/").callsArgWith(1, null, null);
-    mock.expects("opendir").withArgs("/foo").callsArgWith(1, null, null);
-    mock.expects("opendir").withArgs("/foo/bar").callsArgWith(1, null, null);
-    mock.expects("opendir").withArgs("/foo/bar/baz").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("/").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("/foo").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("/foo/bar").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("/foo/bar/baz").callsArgWith(1, null, null);
 
     var finalCallback = sinon.spy();
     helper.sftpRecursiveMkDir(conn, "/foo/bar/baz", {}, finalCallback);
@@ -50,10 +51,10 @@ module.exports = {
   },
   "create directories": function (test) {
     'use strict';
-    mock.expects("opendir").withArgs("/").callsArgWith(1, false, null);
-    mock.expects("opendir").withArgs("/foo").callsArgWith(1, {}, null);
-    mock.expects("opendir").withArgs("/foo/bar").callsArgWith(1, {}, null);
-    mock.expects("opendir").withArgs("/foo/bar/baz").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("/").callsArgWith(1, false, null);
+    mock.expects("stat").withArgs("/foo").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("/foo/bar").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("/foo/bar/baz").callsArgWith(1, {}, null);
 
     mock.expects("mkdir").withArgs("/foo").callsArg(2);
     mock.expects("mkdir").withArgs("/foo/bar").callsArg(2);
@@ -86,9 +87,9 @@ module.exports = {
   },
   "creation fails": function (test) {
     'use strict';
-    mock.expects("opendir").withArgs("/").callsArgWith(1, false, null);
-    mock.expects("opendir").withArgs("/foo").callsArgWith(1, {}, null);
-    mock.expects("opendir").withArgs("/foo/bar").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("/").callsArgWith(1, false, null);
+    mock.expects("stat").withArgs("/foo").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("/foo/bar").callsArgWith(1, {}, null);
 
     mock.expects("mkdir").withArgs("/foo").callsArg(2);
     mock.expects("mkdir").withArgs("/foo/bar").callsArgWith(2, {});


### PR DESCRIPTION
Original problem: `opendir()` fails if given path doesn't have read permissions for
the current user (permissions 0xx).

I'm working with a hosted environment and can't naturally access the root folder. Since the helper function checks existence of directories starting from the root ('/') via trying to open each dir, using sftp with `createDirectories=true` failed for me. Using `stat()` instead of `opendir()` seems to solve the problem, to me it feels like a better way for checking whether a dir exists or not. However, please note that I'm not 100% sure if there were something else behind the way how this helper function is implemented, thus review & testing welcome.

To clarify, the failing scenario with current version can be created as follows:
- Create a sample dir:

```
$ pwd
/path/to/home
$ mkdir private
$ chmod ugo-rxw private/
```
- Try to sftp nested file structure to /path/to/home/private with `createDirectories=true`
- -> Operation will fail
