### PR TITLE
Fix incorrect Connection parameter in execCommand

### DIFF
--- a/tasks/sshexec.js
+++ b/tasks/sshexec.js
@@ -86,7 +86,7 @@ module.exports = function (grunt) {
       } else {
         var command = commands.shift();
         grunt.verbose.writeln('Executing :: ' + command);
-        c.exec(command, options.pty, function (err, stream) {
+        c.exec(command, options, function (err, stream) {
           if (err) {
             throw err;
           }


### PR DESCRIPTION
The ssh2 Connect requires the pty value to reside within the options parameter.
