### PR TITLE
Enable setting of chunkSize used by ssh2 as an option

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -152,7 +152,10 @@ module.exports = function (grunt) {
             }
 
             async.eachSeries(fileQueue, function (file, callback) {
-              var fpOptions;
+              var fpOptions = {
+                step: function () {},
+                chunkSize: options.chunkSize
+              };
 
               if (options.showProgress) {
                 var fileSize = fs.statSync(file.src).size;
@@ -165,14 +168,8 @@ module.exports = function (grunt) {
                   total: fileSize
                 });
 
-                fpOptions = {
-                  step: function (totalSent, lastSent, total) {
+                fpOptions.step = function (totalSent, lastSent, total) {
                     bar.tick(lastSent);
-                  }
-                };
-              } else {
-                fpOptions = {
-                  step: function () {}
                 };
               }
 


### PR DESCRIPTION
We find that our sftp server chokes if the chunk size is too small. This pull request enables the setting of the ssh2 chunkSize option through the grunt config.
