### PR TITLE
Don't add '/' to empty path

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
     setOption('showProgress');
 
     // add trailing slash to path if needed
-    if (!options.path.match(/(\/|\\)$/)) {
+    if ((''!==options.path) && !options.path.match(/(\/|\\)$/)) {
       options.path = options.path + '/';
     }
 


### PR DESCRIPTION
Fix path corruption issue when coping to remote home directory. 
