### PR TITLE
Changed error handling for SFTP

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -197,7 +197,7 @@ module.exports = function (grunt) {
 
     });
     c.on('error', function (err) {
-      grunt.log.error('Connection :: error :: ' + err);
+      grunt.fail.warn('Connection :: error :: ' + err);
     });
     c.on('debug', function (message) {
       grunt.log.debug('Connection :: debug :: ' + message);


### PR DESCRIPTION
Fixes the problems I was having with Issue https://github.com/andrewrjones/grunt-ssh/issues/51 by changing how SFTP errors are handled.  Instead of simply logging and allowing the task to succeed, the task now fails on error.
