### PR TITLE
Added the errors from the ssh lib, just to have more detailed errors

### DIFF
--- a/tasks/lib/sftpHelpers.js
+++ b/tasks/lib/sftpHelpers.js
@@ -21,7 +21,7 @@ exports.init = function (grunt) {
           grunt.verbose.writeln("Creating " + currentPath);
           c.mkdir(currentPath, attributes, function (error) {
             if (error) {
-              finalCallback(false, "Failed to create " + path);
+              finalCallback(false, "Failed to create " + path + " " + error);
             }
             else {
               callback(true);


### PR DESCRIPTION
I've had an error (#101) and it was hard to debug because of the output. I've added the errors that throw the `ssh` lib to have more information in case of error.
Before:
```
>> Error: Path creation failed: Error: Failed to create /dist
```

After
```
>> Error: Path creation failed: Error: Failed to create /dist Error: Permission denied
```

I can add it to the `grunt.verbose.writeln()` instead if you prefer.