### PR TITLE
Updated the documentation to clarify the path when sftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ files: {
 
 ###### path ```string```
 
-The path on the remote server. Defaults to home.
+The path on the remote server. Defaults to `/`.
 
 ###### minimatch ```object```
 


### PR DESCRIPTION
I've had an error (#101) and by debuging it i think the documentation should be changed, because the default path it's not home, it's `/` as you can see here: https://github.com/chuckmo/grunt-ssh/blob/master/tasks/lib/sftpHelpers.js#L15.

I will create another PR that don't changes the documentation and fixes the code to set the default to home, and then you decide which one you want.