### PR TITLE
Changed the default directory of SFTP from / to ./ (home)

### DIFF
--- a/tasks/lib/sftpHelpers.js
+++ b/tasks/lib/sftpHelpers.js
@@ -12,7 +12,7 @@ exports.init = function (grunt) {
     var pathParts = path.split("/").filter(function (part) {
       return part !== "";
     });
-    var currentPath = "/";
+    var currentPath = "./";
     var ptr = 0;
 
     var mkdir = function (path, callback) {

--- a/test/sftpHelpers_test.js
+++ b/test/sftpHelpers_test.js
@@ -38,10 +38,10 @@ module.exports = {
   },
   "existing directories": function (test) {
     'use strict';
-    mock.expects("stat").withArgs("/").callsArgWith(1, null, null);
-    mock.expects("stat").withArgs("/foo").callsArgWith(1, null, null);
-    mock.expects("stat").withArgs("/foo/bar").callsArgWith(1, null, null);
-    mock.expects("stat").withArgs("/foo/bar/baz").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("./").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("./foo").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("./foo/bar").callsArgWith(1, null, null);
+    mock.expects("stat").withArgs("./foo/bar/baz").callsArgWith(1, null, null);
 
     var finalCallback = sinon.spy();
     helper.sftpRecursiveMkDir(conn, "/foo/bar/baz", {}, finalCallback);
@@ -51,14 +51,14 @@ module.exports = {
   },
   "create directories": function (test) {
     'use strict';
-    mock.expects("stat").withArgs("/").callsArgWith(1, false, null);
-    mock.expects("stat").withArgs("/foo").callsArgWith(1, {}, null);
-    mock.expects("stat").withArgs("/foo/bar").callsArgWith(1, {}, null);
-    mock.expects("stat").withArgs("/foo/bar/baz").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("./").callsArgWith(1, false, null);
+    mock.expects("stat").withArgs("./foo").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("./foo/bar").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("./foo/bar/baz").callsArgWith(1, {}, null);
 
-    mock.expects("mkdir").withArgs("/foo").callsArg(2);
-    mock.expects("mkdir").withArgs("/foo/bar").callsArg(2);
-    mock.expects("mkdir").withArgs("/foo/bar/baz").callsArg(2);
+    mock.expects("mkdir").withArgs("./foo").callsArg(2);
+    mock.expects("mkdir").withArgs("./foo/bar").callsArg(2);
+    mock.expects("mkdir").withArgs("./foo/bar/baz").callsArg(2);
 
     var finalCallback = sinon.spy();
     helper.sftpRecursiveMkDir(conn, "/foo/bar/baz", {}, finalCallback);
@@ -87,12 +87,12 @@ module.exports = {
   },
   "creation fails": function (test) {
     'use strict';
-    mock.expects("stat").withArgs("/").callsArgWith(1, false, null);
-    mock.expects("stat").withArgs("/foo").callsArgWith(1, {}, null);
-    mock.expects("stat").withArgs("/foo/bar").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("./").callsArgWith(1, false, null);
+    mock.expects("stat").withArgs("./foo").callsArgWith(1, {}, null);
+    mock.expects("stat").withArgs("./foo/bar").callsArgWith(1, {}, null);
 
-    mock.expects("mkdir").withArgs("/foo").callsArg(2);
-    mock.expects("mkdir").withArgs("/foo/bar").callsArgWith(2, {});
+    mock.expects("mkdir").withArgs("./foo").callsArg(2);
+    mock.expects("mkdir").withArgs("./foo/bar").callsArgWith(2, {});
 
     var finalCallback = sinon.spy();
     helper.sftpRecursiveMkDir(conn, "/foo/bar/baz", {}, finalCallback);


### PR DESCRIPTION
This PR is the one mentioned on #104 , it sets the default directory of SFTP to the home of the user (ex: `/home/deploy`) instead of going to the `/` of the server. This way is the one described on the documentation.

This PR may brake some old configurations, more exactly if you have a path defined.