### PR TITLE
Support agentForwarding when using password

### DIFF
--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -93,6 +93,9 @@ exports.init = function (grunt) {
     }
     else if (options.password) {
       connectionOptions.password = options.password;
+      if (options.agent) {
+        connectionOptions.agent = options.agent;
+      }
     } else {
       connectionOptions.agent = options.agent;
     }


### PR DESCRIPTION
This adresses issue chuckmo/grunt-ssh#107 and fixes it. It's a simple fix: even when `password` is set, still set the `agent` if it's available. 