### PR TITLE
added callback option to the sftp task

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -36,7 +36,8 @@ module.exports = function (grunt) {
       createDirectories: false,
       directoryPermissions: parseInt(755, 8),
       showProgress: false,
-      mode: 'upload'
+      mode: 'upload',
+      callback: function() {}
     });
 
     var tally = {
@@ -393,6 +394,7 @@ module.exports = function (grunt) {
       grunt.log.writeln((
       tally.dirs ? 'Created ' + tally.dirs.toString().cyan + ' directories, copied ' : 'Copied ') + (tally.files ? tally.files.toString().cyan + ' files' : ''));
       grunt.verbose.writeln('Connection :: close');
+      options.callback.call();
       done();
     });
 


### PR DESCRIPTION
Hi,
According to the README file, the `sftp` task should have a `callback` option to be called when transferring files is finished. however this option is not yet implemented.
this simple pull request creates this option.

Thanks
