### PR TITLE
Fixes chuckmo/grunt-ssh#119

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -184,7 +184,7 @@ module.exports = function (grunt) {
                               callback();
                             }
                             list.forEach(function (item) {
-                              downloadingRecursive(path.join(directorySrc, item.filename), path.join(directoryDest, item.filename));
+                              downloadingRecursive(path.posix.join(directorySrc, item.filename), path.join(directoryDest, item.filename));
                             });
                           });
                         };


### PR DESCRIPTION
Force use of posix path join for src (SSH) path, but keep os-dependent join for destination (local) path