### PR TITLE
Bump async to at least v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "ssh2": "~0.4.6",
-    "async": "*",
+    "async": ">=1.0.0",
     "progress": "~1.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
With npm 3, the dependencies are automagically flattened, which meant that for us grunt-ssh ended up using async@0.1, because some other dependencies rely on it and so grunt-ssh was failing due to `async.eachSeries` not being defined.