### PR TITLE
Add function test for path option

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -66,6 +66,11 @@ module.exports = function (grunt) {
     setOption('passphrase');
     setOption('showProgress');
 
+    // invoke path function (if applicable)
+    if (typeof(options.path) === 'function') {
+      options.path = options.path();
+    }
+
     // add trailing slash to path if needed
     if (('' !== options.path) && !options.path.match(/(\/|\\)$/)) {
       options.path = options.path + '/';


### PR DESCRIPTION
This PR allows you to pass a function, which returns a string, to the `path` option. This allows you to change the path based on arguments sent through in the Grunt task.

e.g. running `grunt stfp:cdn:dev` and having as a `path` option:

``` js
path: function() {
  var type = grunt.task.current.args[0] || "dev";
  return "/path/to/my/cdn/"+type+"/";
}
```

I'm using it to upload to a different directory on our CDN based on the version number.
