### PR TITLE
fixing windows-client unix-server recursive downloads

### DIFF
--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -184,7 +184,7 @@ module.exports = function (grunt) {
                               callback();
                             }
                             list.forEach(function (item) {
-                              downloadingRecursive(path.join(directorySrc, item.filename), path.join(directoryDest, item.filename));
+                              downloadingRecursive(path.posix.join(directorySrc, item.filename), path.posix.join(directoryDest, item.filename));
                             });
                           });
                         };


### PR DESCRIPTION
recursive download now using POSIX paths so a windows client can download from an unix server (was generating back slashed paths)