### PR TITLE
update SSH2 to support modern Node versions, add a debug_ssh2 option 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ npm-debug.log
 secret*.json
 *.sublime-*
 .idea
+package-lock.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,10 +80,9 @@ module.exports = function (grunt) {
         command: ['uptime', 'ls', 'uptime'],
         options: {
           host: secret.host,
+          port: secret.port,
           username: secret.username,
-          // private key auth
-          //privateKey: grunt.file.read(secret.privateKeyPath),
-          passphrase: secret.passphrase
+          password: secret.password,
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 **New owner!** Starting 12-23-2015, I (@israelroldan) am standing on the shoulders of two giants (@chuckmo and @andrewrjones) as maintainer of this project. Contributions are welcome as always.
 (This message will be removed on next release as well).
 
+Fork by @Xfennec with (relatively) up-to-date `ssh2` dependency.
+
 # grunt-ssh
 
 [![Join the chat at https://gitter.im/israelroldan/grunt-ssh](https://badges.gitter.im/israelroldan/grunt-ssh.svg)](https://gitter.im/israelroldan/grunt-ssh?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -215,7 +217,7 @@ options will be ignored. Each is described a bit more below.
 
 A string containing the contents of the private key to use to authenticate with the remote system, you can load this from a file using ```grunt.file.read```. Be careful you don't put this into source control unless you mean it!
 
-If a privateKey and passphrase are required, they 
+If a privateKey and passphrase are required, they
 
 ```js
 options: {
@@ -244,11 +246,15 @@ options: {
          agent: process.env.SSH_AUTH_SOCK
 }
 ```
-If you use ```jshint```, remember to add ```process: true``` in ```globals``` 
+If you use ```jshint```, remember to add ```process: true``` in ```globals```
 
 ###### readyTimeout ```integer```
 
 How often (in milliseconds) to wait for the SSH handshake to complete.
+
+###### debug_ssh2 ```boolean```
+
+If true, the ssh2 library will output debug messages. This is useful for debugging connection issues.
 
 ### sshexec
 
@@ -329,7 +335,7 @@ options: {
 }
 ```
 
-If you use ```jshint```, remember to add ```process: true``` in ```globals``` 
+If you use ```jshint```, remember to add ```process: true``` in ```globals```
 
 ###### readyTimeout ```integer```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ssh-xf",
   "description": "SSH and SFTP tasks for Grunt",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "homepage": "https://github.com/israelroldan/grunt-ssh",
   "author": {
     "name": "Andrew Jones",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "grunt-ssh",
+  "name": "grunt-ssh-xf",
   "description": "SSH and SFTP tasks for Grunt",
   "version": "0.12.9",
   "homepage": "https://github.com/israelroldan/grunt-ssh",
@@ -10,10 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/israelroldan/grunt-ssh.git"
-  },
-  "bugs": {
-    "url": "https://github.com/israelroldan/grunt-ssh/issues"
+    "url": "git://github.com/Xfennec/grunt-ssh.git"
   },
   "license": "MIT",
   "main": "grunt.js",
@@ -24,7 +21,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "ssh2": "~0.4.6",
+    "ssh2": "~1.16.0",
     "async": ">=1.0.0",
     "progress": "~1.1.3"
   },
@@ -89,6 +86,7 @@
     "Justin Kulesza <justin.kulesza@atomicobject.com>",
     "Michael Lam <treadsafely@gmail.com>",
     "Niels van Aken <vanaken@10uur.nl>",
-    "Uri Chandler <uri@kungfoo.bar>"
+    "Uri Chandler <uri@kungfoo.bar>",
+    "Xfennec <xfennec@cqfd-corp.org>"
   ]
 }

--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -100,6 +100,12 @@ exports.init = function (grunt) {
       connectionOptions.agent = options.agent;
     }
 
+    if (options.debug_ssh2) {
+      connectionOptions.debug = function (message) {
+        grunt.log.writeln(message);
+      };
+    }
+
     return connectionOptions;
   };
 

--- a/tasks/sftp.js
+++ b/tasks/sftp.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
     var utillib = require('./lib/util').init(grunt);
     var fs = require('fs');
     var async = require('async');
-    var Connection = require('ssh2');
+    var { Client } = require('ssh2');
     var path = require('path');
     var sftpHelper = require("./lib/sftpHelpers").init(grunt);
     var ProgressBar = require('progress');
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
 
     var files = this.files;
 
-    var c = new Connection();
+    var c = new Client();
     var done = this.async();
 
     c.on('keyboard-interactive', function(){

--- a/tasks/sshexec.js
+++ b/tasks/sshexec.js
@@ -15,8 +15,8 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('sshexec', 'Executes a shell command on a remote machine', function () {
     var utillib = require('./lib/util').init(grunt);
-    var Connection = require('ssh2');
-    var c = new Connection();
+    var { Client } = require('ssh2');
+    var c = new Client();
 
     var done = this.async();
 


### PR DESCRIPTION
With Node v22, tasks silently fails:
```
[…]
DEBUG: Checking host key format
DEBUG: Checking signature format
DEBUG: Verifying host fingerprint
DEBUG: Host accepted by default (no verification)
DEBUG: Verifying signature
DEBUG: Signature could not be verified
DEBUG: Outgoing: Writing DISCONNECT (KEY_EXCHANGE_FAILED)
Connection :: end
```

Updating to the latest `ssh2` release fixes this issue (and probably many others). I've also added a `debug_ssh2` boolean setting to help diagnose such issues.

I've published a `grunt-ssh-xf` npm package with this patch, if anyone wants a quick fix for this issue.